### PR TITLE
mastopurge never pulled more than one page of toots

### DIFF
--- a/mastopurge.go
+++ b/mastopurge.go
@@ -326,7 +326,6 @@ func main() {
 				log.Fatal(err)
 			}
 			pinnedStatusIds := getStatusIds(pinnedStatuses)
-			log.Printf("Found %d pinned statuses, which will not be deleted.", len(pinnedStatusIds))
 
 			var maxid uint64 = 0
 			var prevmaxid uint64 = 1
@@ -353,6 +352,7 @@ func main() {
 
 				var statuses []Status
 				err = json.Unmarshal(resp, &statuses)
+				log.Printf("Found %d status", len(statuses))
 				if err != nil {
 					// Maybe server response is an error message?
 					log.Println(string(resp))
@@ -399,8 +399,8 @@ func main() {
 					}
 
 					if status.ID < maxid || maxid == 0 {
-						maxid = status.ID - 1
 						prevmaxid = maxid
+						maxid = status.ID - 1
 					}
 				}
 

--- a/mastopurge.go
+++ b/mastopurge.go
@@ -326,6 +326,7 @@ func main() {
 				log.Fatal(err)
 			}
 			pinnedStatusIds := getStatusIds(pinnedStatuses)
+			log.Printf("Found %d pinned statuses, which will not be deleted.", len(pinnedStatusIds))
 
 			var maxid uint64 = 0
 			var prevmaxid uint64 = 1
@@ -352,7 +353,6 @@ func main() {
 
 				var statuses []Status
 				err = json.Unmarshal(resp, &statuses)
-				log.Printf("Found %d status", len(statuses))
 				if err != nil {
 					// Maybe server response is an error message?
 					log.Println(string(resp))


### PR DESCRIPTION
Prior to this change _prevmaxid_ was always updated after updating _maxid_ and thus both were always identical. This in turn caused the loop to break after the first run (line 362 of mastopurge.go).

Updating prevmaxid before maxid fixed the issue for me and mastopurge now works fine deleting old toots that are not on the first results page.