### PR TITLE
Add feature / option to undo favourites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+APP := mastopurge
+VERSION := $(git describe --tags --exact-match || git rev-parse --short HEAD)
+
+# -s -w: omit debug and similar symbols.
+LD_FLAGS := "-s -w -X 'main.versionString=$(VERSION)'"
+
+PKG_LIST := mastopurge.go api.go
+
+.PHONY: clean \
+	test \
+	run \
+	lint
+
+mastopurge: build
+
+# Starts at generate.go. Also processes all occurrances of //go:generate
+generate:
+	@ go generate
+
+build: $(PKG_LIST)
+	@ go build -o $(APP) -ldflags=$(LD_FLAGS) $(PKG_LIST)
+
+# Debug build
+debug: $(PKG_LIST)
+	@ go build -o $(APP) $(PKG_LIST)
+
+run:
+	@ go run $(PKG_LIST)
+
+clean:
+	@ go clean -modcache
+	@ rm -f $(APP)
+
+test:
+	go test -cover -race -count=1 ./...

--- a/README.md
+++ b/README.md
@@ -71,3 +71,19 @@ If you'd like to check whether Mastopurge works properly (without actually delet
 ```
 ./mastopurge --noninteractive --maxage "30 days" --dryrun
 ```
+
+### Favourites
+
+If you want to undo favourites, add the `--favs` parameter:
+
+```
+./mastopurge --maxage "365 days" --favs
+```
+
+### Verbose output
+
+If you are really curious about some internals, add verbose output:
+
+```
+./mastopurge --maxage "365 days" --verbose
+````

--- a/api.go
+++ b/api.go
@@ -77,7 +77,6 @@ func (c *APIClient) RequestWithLink(method, endpoint string, params url.Values) 
 
 		// Fetch 'Link' header. Empty string, if none is available.
 		linkHeader = res.Header.Get("Link")
-		fmt.Printf("found Link header: %s", linkHeader)
 
 		// Only exit if request was not API rate limited
 		if !rateLimited(res) {

--- a/api.go
+++ b/api.go
@@ -32,6 +32,15 @@ func (c *APIClient) Init() {
 // e.g. GET or POST, whereas endpoint is the API endpoint to which we should
 // make the request.
 func (c *APIClient) Request(method, endpoint string, params url.Values) (body []byte, err error) {
+	body, _, err := c.RequestWithLink(method, endpoint, params)
+	return body, err
+}
+
+// RequestWithLink makes a new request to the API. method is the HTTP method to use,
+// e.g. GET or POST, whereas endpoint is the API endpoint to which we should
+// make the request.
+// Returns the 'Link' header with either an empty string or links to the previous or next chunk.
+func (c *APIClient) RequestWithLink(method, endpoint string, params url.Values) (body []byte, linkHeader string, err error) {
 	// Set up request: if it's a POST/PUT, we make the body urlencoded.
 	uri := c.Server + endpoint
 	var req *http.Request
@@ -64,13 +73,17 @@ func (c *APIClient) Request(method, endpoint string, params url.Values) (body []
 			log.Fatal(err)
 		}
 
+		// Fetch 'Link' header. Empty string, if none is available.
+		linkHeader := res.Header.Get("Link")
+		fmt.Printf("found Link header: %s", linkHeader)
+
 		// Only exit if request was not API rate limited
 		if rateLimited(res) == false {
 			break
 		}
 	}
 
-	return body, nil
+	return body, linkHeader, nil
 }
 
 // rateLimited checks if API throttling is active. If yes, it waits the time

--- a/api.go
+++ b/api.go
@@ -32,7 +32,7 @@ func (c *APIClient) Init() {
 // e.g. GET or POST, whereas endpoint is the API endpoint to which we should
 // make the request.
 func (c *APIClient) Request(method, endpoint string, params url.Values) (body []byte, err error) {
-	body, _, err := c.RequestWithLink(method, endpoint, params)
+	body, _, err = c.RequestWithLink(method, endpoint, params)
 	return body, err
 }
 
@@ -62,6 +62,8 @@ func (c *APIClient) RequestWithLink(method, endpoint string, params url.Values) 
 		req.Header.Set("Authorization", "Bearer "+c.AccessToken)
 	}
 
+	// Keep going until we get the response,
+	// possibly including some waiting around for API rate limits.
 	for {
 		res, geterr := c.Client.Do(req)
 		if geterr != nil {
@@ -74,11 +76,11 @@ func (c *APIClient) RequestWithLink(method, endpoint string, params url.Values) 
 		}
 
 		// Fetch 'Link' header. Empty string, if none is available.
-		linkHeader := res.Header.Get("Link")
+		linkHeader = res.Header.Get("Link")
 		fmt.Printf("found Link header: %s", linkHeader)
 
 		// Only exit if request was not API rate limited
-		if rateLimited(res) == false {
+		if !rateLimited(res) {
 			break
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module mastopurge
+
+go 1.17

--- a/mastopurge.go
+++ b/mastopurge.go
@@ -89,6 +89,7 @@ var (
 	printVersion       = flag.Bool("version", false, "Print version, and exit.")
 	quietMode          = flag.Bool("quiet", false, "Reduce output to the most important messages only.")
 	dryRun             = flag.Bool("dryrun", false, "Run MastoPurge to preview its results, but without actually deleting any statuses.")
+	purgeFavs					 = flag.Bool("favs", false, "Purge favourites in addition to toots.")
 )
 
 var versionString string = "0.0.0"
@@ -437,18 +438,20 @@ func main() {
 			}
 
 			// Go hunting likes.
-			numFavsDeleted, err := deleteFavourites(maxtime, *dryRun, hc, accountinfo)
-			if err != nil {
-				log.Fatal(err)
+			if *purgeFavs {
+				numFavsDeleted, err := purgeFavourites(maxtime, *dryRun, hc, accountinfo)
+				if err != nil {
+					log.Fatal(err)
+				}
+				fmt.Printf(">>>>>> Deleted %d favourites.\n", numFavsDeleted)
 			}
-			fmt.Printf(">>>>>> Deleted %d favourites.\n", numFavsDeleted)
 		}
 	}
 }
 
 // deleteFavourites looks for all favs made by the user that are older than maxtime.
 // Returns the number of deleted favourites and any error that might have occured.
-func deleteFavourites(maxtime time.Time, dryRun bool, apiClient *APIClient, accountInfo AccountInfo) (numFavsDeleted int, err error) {
+func purgeFavourites(maxtime time.Time, dryRun bool, apiClient *APIClient, accountInfo AccountInfo) (numFavsDeleted int, err error) {
 	// TODO Fetch favs, ignoring everything younger than maxtime.
 	// GET /api/v1/favourites
 	params := url.Values{}

--- a/mastopurge.go
+++ b/mastopurge.go
@@ -464,7 +464,7 @@ func purgeFavourites(maxtime time.Time, dryRun bool, apiClient *APIClient, accou
 	for {
 		requestCount++
 		chunk := getChunkOfFavs(apiClient, maxId)
-		log.Printf("  ..got chunk of %d favs..", len(chunk))
+		log.Printf("  ..got chunk of %d favs. Last one has id=%d, was posted by=%s at %s", len(chunk), chunk[len(chunk)-1].ID, [len(chunk)-1].Account.Username, chunk[len(chunk)-1].CreatedAt)
 
 		for i := 0; i < len(chunk); i++ {
 			favs = append(favs, chunk[i])
@@ -499,7 +499,7 @@ func getChunkOfFavs(apiClient *APIClient, maxId uint64) []Status {
 	params := url.Values{}
 	params.Add("limit", strconv.Itoa(Pagelimit))
 	if maxId != 0 {
-		params.Add("max_id", fmt.Sprint(maxId))
+		// params.Add("max_id", fmt.Sprint(maxId))
 	}
 	respBody, err := apiClient.Request(http.MethodGet, "/api/v1/favourites", params)
 	if err != nil {

--- a/mastopurge.go
+++ b/mastopurge.go
@@ -427,12 +427,26 @@ func main() {
 				log.Println("[dryRun] 0 statuses deleted in total, because -dryRun was passed.")
 			}
 
-			// No more pages, done! :-)
+			// No more pages, done deleting posts. :-)
 			if interactiveMode {
 				fmt.Println(">>>>>> ", deletedcount, "statuses were successfully deleted.")
 			} else {
 				log.Println(deletedcount, "statuses were successfully deleted.")
 			}
+
+			// Go hunting likes.
+			numFavsDeleted, err := deleteFavourites(hc)
+			if err != nil {
+				log.Fatal(err)
+			}
+			log.Printf("Deleted %d favourites.\n", numFavsDeleted)
 		}
 	}
+}
+
+// deleteFavourites looks for all favs made by the user that are older than maxtime.
+// Returns the number of deleted favourites and any error that might have occured.
+func deleteFavourites(maxtime time.Time, httpClient *APIClient) (numFavsDeleted int, err error) {
+	// TODO Implement
+	return 0, nil
 }


### PR DESCRIPTION
By using a new `--favs` option, favourites of posts can be undone. Additionally, a `--verbose` option allows to be just that: more verbose in the output.