### PR TITLE
make runnable on more systems

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### Get VERSIONSTRING from Git
 VERSIONSTRING="$(git describe --tags --exact-match || git rev-parse --short HEAD)"


### PR DESCRIPTION
not all systems keep executables or symlinks in /bin/